### PR TITLE
Bumps clojure, clj-time, & core.async versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "https://github.com/james-henderson/chime.git"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-time/clj-time "0.6.0"]
-                 [org.clojure/core.async "0.1.303.0-886421-alpha"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [clj-time/clj-time "0.11.0"]
+                 [org.clojure/core.async "0.2.374"]])

--- a/src/chime.clj
+++ b/src/chime.clj
@@ -22,9 +22,9 @@
 
   Usage:
 
-    (let [chimes (chime-ch [(-> 2 t/secs t/ago) ; has already passed, will be ignored.
-                            (-> 2 t/secs t/from-now)
-                            (-> 3 t/secs t/from-now)])]
+    (let [chimes (chime-ch [(-> 2 t/seconds t/ago) ; has already passed, will be ignored.
+                            (-> 2 t/seconds t/from-now)
+                            (-> 3 t/seconds t/from-now)])]
       (a/<!! (go-loop []
                (when-let [msg (<! chimes)]
                  (prn \"Chiming at:\" msg)
@@ -82,23 +82,23 @@
 (comment
   ;; some quick tests ;)
 
-  (chime-at [(-> 2 t/secs t/ago)
-             (-> 2 t/secs t/from-now)
-             (-> 3 t/secs t/from-now)
-             (-> 5 t/secs t/from-now)]
+  (chime-at [(-> 2 t/seconds t/ago)
+             (-> 2 t/seconds t/from-now)
+             (-> 3 t/seconds t/from-now)
+             (-> 5 t/seconds t/from-now)]
             #(println "Chiming!" %))
 
-  (let [chimes (chime-ch [(-> 2 t/secs t/ago)
-                          (-> 2 t/secs t/from-now)
-                          (-> 3 t/secs t/from-now)])]
+  (let [chimes (chime-ch [(-> 2 t/seconds t/ago)
+                          (-> 2 t/seconds t/from-now)
+                          (-> 3 t/seconds t/from-now)])]
     (a/<!! (go-loop []
              (when-let [msg (<! chimes)]
                (prn "Chiming at:" msg)
                (recur)))))
 
-  (let [chimes (chime-ch [(-> 2 t/secs t/ago)
-                          (-> 2 t/secs t/from-now)
-                          (-> 3 t/secs t/from-now)])]
+  (let [chimes (chime-ch [(-> 2 t/seconds t/ago)
+                          (-> 2 t/seconds t/from-now)
+                          (-> 3 t/seconds t/from-now)])]
 
     (a/<!!
      (a/go
@@ -106,7 +106,7 @@
        (a/close! chimes)
        (prn (<! chimes)))))
 
-  (chime-at [(-> 2 t/secs t/from-now) (-> 4 t/secs t/from-now)]
+  (chime-at [(-> 2 t/seconds t/from-now) (-> 4 t/seconds t/from-now)]
 
             (fn [time]
               (println "Chiming at" time))


### PR DESCRIPTION
- clojure v1.7.0
- clj-time v0.11.0
- core.async v0.2.374
- Replaces deprecated clj-time.core/secs with /seconds