### PR TITLE
Readme: Rm link to tick as a scheduling lib

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,14 +2,6 @@
 
 Chime is a *really* lightweight Clojure scheduler.
 
-#+BEGIN_QUOTE
-I'd recommend you check out [[https://github.com/juxt/tick][JUXT's 'tick']] library - it's likely going to get more community support with JUXT's backing than I can give Chime.
-
-Thank you for all your help and support with Chime!
-
-James
-#+END_QUOTE
-
 ** Dependency
 
 Add the following to your =project.clj= file:


### PR DESCRIPTION
because its scheduling has been deprecated: https://github.com/juxt/tick/blob/master/src/tick/deprecated/schedule.clj